### PR TITLE
feat(hooks): add before/after lifecycle hooks and shared write helpers

### DIFF
--- a/src/hooks/after.ts
+++ b/src/hooks/after.ts
@@ -1,0 +1,61 @@
+import { createAuthMiddleware } from "better-auth/api";
+import type { HookEndpointContext } from "@better-auth/core";
+import type { AuditLogStatus, ResolvedOptions } from "../types";
+import { buildLogEntry, writeEntry } from "../internal";
+import { BEFORE_PATHS } from "./before";
+
+export function createAfterHooks(opts: ResolvedOptions, modelName: string) {
+  return [
+    {
+      matcher: (context: HookEndpointContext) =>
+        !!context.path &&
+        !BEFORE_PATHS.some((p) => context.path!.startsWith(p)) &&
+        opts.shouldCapture(context.path!),
+
+      handler: createAuthMiddleware(async (ctx) => {
+        try {
+          const path = ctx.path!;
+          const isError = ctx.context.returned instanceof Error;
+          const status: AuditLogStatus = isError ? "failed" : "success";
+
+          const user =
+            ctx.context.newSession?.user ?? ctx.context.session?.user;
+
+          const pathConfig = opts.getPathConfig(path);
+
+          const metadata: Record<string, unknown> = {};
+
+          if (opts.capture.requestBody && ctx.body) {
+            metadata.requestBody = ctx.body as Record<string, unknown>;
+          }
+
+          if (isError) {
+            const err = ctx.context.returned as Error & {
+              status?: number;
+              code?: string;
+            };
+            metadata.error = {
+              message: err.message,
+              ...(err.status !== undefined && { status: err.status }),
+              ...(err.code !== undefined && { code: err.code }),
+            };
+          }
+
+          const entry = await buildLogEntry(path, status, {
+            userId: user?.id ?? null,
+            request: ctx.request,
+            headers: ctx.headers,
+            metadata,
+            pathConfig,
+            options: opts,
+            authOptions: ctx.context.options,
+          });
+
+          await writeEntry(ctx, entry, opts, modelName);
+        } catch (err) {
+          ctx.context.logger?.error("[audit-log] after hook failed", err);
+        }
+      }),
+    },
+  ];
+}

--- a/src/hooks/before.ts
+++ b/src/hooks/before.ts
@@ -1,0 +1,44 @@
+import { createAuthMiddleware, getSessionFromCtx } from "better-auth/api";
+import type { HookEndpointContext } from "@better-auth/core";
+import type { ResolvedOptions } from "../types";
+import { buildLogEntry, writeEntry } from "../internal";
+
+export const BEFORE_PATHS = [
+  "/sign-out",
+  "/delete-user",
+  "/revoke-session",
+  "/revoke-sessions",
+  "/revoke-other-sessions",
+] as const;
+
+export function createBeforeHooks(opts: ResolvedOptions, modelName: string) {
+  return [
+    {
+      matcher: (context: HookEndpointContext) =>
+        !!context.path &&
+        BEFORE_PATHS.some((p) => context.path!.startsWith(p)) &&
+        opts.shouldCapture(context.path!),
+
+      handler: createAuthMiddleware(async (ctx) => {
+        try {
+          const session = await getSessionFromCtx(ctx);
+          const path = ctx.path!;
+          const pathConfig = opts.getPathConfig(path);
+
+          const entry = await buildLogEntry(path, "success", {
+            userId: session?.user?.id ?? null,
+            request: ctx.request,
+            headers: ctx.headers,
+            pathConfig,
+            options: opts,
+            authOptions: ctx.context.options,
+          });
+
+          await writeEntry(ctx, entry, opts, modelName);
+        } catch (err) {
+          ctx.context.logger?.error("[audit-log] before hook failed", err);
+        }
+      }),
+    },
+  ];
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { createBeforeHooks, BEFORE_PATHS } from "./before";
+export { createAfterHooks } from "./after";

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,0 +1,136 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+  AuditLogEntry,
+  AuditLogStatus,
+  PathConfig,
+  ResolvedOptions,
+} from "./types";
+import {
+  normalizePath,
+  inferSeverity,
+  extractRequestMeta,
+  redactPII,
+} from "./utils";
+
+interface BuildParams {
+  userId: string | null;
+  request: Request | undefined;
+  headers: Headers | undefined;
+  metadata?: Record<string, unknown>;
+  pathConfig?: PathConfig;
+  options: ResolvedOptions;
+  authOptions: GenericEndpointContext["context"]["options"];
+}
+
+export async function buildLogEntry(
+  path: string,
+  status: AuditLogStatus,
+  params: BuildParams,
+): Promise<Omit<AuditLogEntry, "id">> {
+  const action = normalizePath(path);
+  const severity =
+    params.pathConfig?.severity ?? inferSeverity(action, status);
+
+  const captureOpts = {
+    ...params.options.capture,
+    ...params.pathConfig?.capture,
+  };
+
+  const { ipAddress, userAgent } = extractRequestMeta(
+    captureOpts.ipAddress !== false ? params.request : undefined,
+    captureOpts.userAgent !== false ? params.headers : undefined,
+    params.authOptions,
+  );
+
+  let metadata = params.metadata ?? {};
+  if (params.options.piiRedaction.enabled) {
+    metadata = await redactPII(metadata, params.options.piiRedaction);
+  }
+
+  return {
+    userId: params.userId,
+    action,
+    status,
+    severity,
+    ipAddress,
+    userAgent,
+    metadata,
+    createdAt: new Date(),
+  };
+}
+
+export async function buildLogEntryFromAction(
+  action: string,
+  status: AuditLogStatus,
+  params: Omit<BuildParams, "pathConfig">,
+): Promise<Omit<AuditLogEntry, "id">> {
+  const severity = inferSeverity(action, status);
+
+  const { ipAddress, userAgent } = extractRequestMeta(
+    params.options.capture.ipAddress !== false ? params.request : undefined,
+    params.options.capture.userAgent !== false ? params.headers : undefined,
+    params.authOptions,
+  );
+
+  let metadata = params.metadata ?? {};
+  if (params.options.piiRedaction.enabled) {
+    metadata = await redactPII(metadata, params.options.piiRedaction);
+  }
+
+  return {
+    userId: params.userId,
+    action,
+    status,
+    severity,
+    ipAddress,
+    userAgent,
+    metadata,
+    createdAt: new Date(),
+  };
+}
+
+export async function writeEntry(
+  ctx: GenericEndpointContext,
+  entry: Omit<AuditLogEntry, "id">,
+  opts: ResolvedOptions,
+  modelName: string,
+): Promise<void> {
+  let finalEntry = entry;
+
+  if (opts.beforeLog) {
+    const modified = await opts.beforeLog(finalEntry);
+    if (modified === null) return;
+    finalEntry = modified;
+  }
+
+  const doWrite = async () => {
+    let written: AuditLogEntry;
+
+    if (opts.storage) {
+      written = { id: crypto.randomUUID(), ...finalEntry };
+      await opts.storage.write(written);
+    } else {
+      const record = await ctx.context.adapter.create<Record<string, unknown>>({
+        model: modelName,
+        data: {
+          ...finalEntry,
+          metadata: JSON.stringify(finalEntry.metadata),
+        },
+      });
+      // Reconstruct with parsed metadata — the DB stores it as a JSON string
+      written = { ...(record as Omit<AuditLogEntry, "metadata">), metadata: finalEntry.metadata };
+    }
+
+    if (opts.afterLog) await opts.afterLog(written);
+  };
+
+  if (opts.nonBlocking) {
+    ctx.context.runInBackground(
+      doWrite().catch((err) =>
+        ctx.context.logger?.error("[audit-log] write failed", err),
+      ),
+    );
+  } else {
+    await doWrite();
+  }
+}


### PR DESCRIPTION
internal.ts:
- buildLogEntry: normalises path to action, infers severity, extracts IP/UA, applies PII redaction — shared by hooks and the manual insert endpoint
- buildLogEntryFromAction: variant for free-form action strings (manual inserts)
- writeEntry: single write path for both DB adapter and custom storage; reconstructs AuditLogEntry with parsed metadata after DB write so afterLog callback always receives the correct shape; nonBlocking delegates to ctx.context.runInBackground

hooks/before.ts:
- Fires for sign-out, delete-user, revoke-session(s), revoke-other-sessions
- Reads session via getSessionFromCtx BEFORE the handler executes, since these paths destroy the session during execution
- Errors are caught and logged — never block the auth flow

hooks/after.ts:
- Fires for all other POST paths not in the before-only list
- Reads userId from ctx.context.newSession (fresh login) or ctx.context.session (existing session mutations); falls back to null for failed attempts
- ctx.context.returned instanceof Error determines success vs failed status
- Error details (message, status, code) captured in metadata when available