### PR TITLE
feat(endpoints): add list, get-by-id, and manual insert log endpoints

### DIFF
--- a/src/endpoints/get-log.ts
+++ b/src/endpoints/get-log.ts
@@ -1,0 +1,47 @@
+import { createAuthEndpoint, sessionMiddleware, APIError } from "better-auth/api";
+import type { AuditLogEntry, ResolvedOptions } from "../types";
+
+export function createGetLogEndpoint(opts: ResolvedOptions, modelName: string) {
+  return createAuthEndpoint(
+    "/audit-log/:id",
+    { method: "GET", use: [sessionMiddleware] },
+    async (ctx) => {
+      const { id } = ctx.params as { id: string };
+      const session = ctx.context.session;
+
+      if (opts.storage?.readById) {
+        const entry = await opts.storage.readById(id);
+        if (!entry || entry.userId !== session.user.id) {
+          throw new APIError("NOT_FOUND", {
+            message: "Audit log entry not found",
+          });
+        }
+        return ctx.json(entry);
+      }
+
+      const record = await ctx.context.adapter.findOne<Record<string, unknown>>({
+        model: modelName,
+        where: [
+          { field: "id", value: id },
+          { field: "userId", value: session.user.id },
+        ],
+      });
+
+      if (!record) {
+        throw new APIError("NOT_FOUND", {
+          message: "Audit log entry not found",
+        });
+      }
+
+      const entry: AuditLogEntry = {
+        ...(record as Omit<AuditLogEntry, "metadata">),
+        metadata:
+          typeof record["metadata"] === "string"
+            ? (JSON.parse(record["metadata"]) as Record<string, unknown>)
+            : ((record["metadata"] as Record<string, unknown>) ?? {}),
+      };
+
+      return ctx.json(entry);
+    },
+  );
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,0 +1,3 @@
+export { createListLogsEndpoint } from "./list-logs";
+export { createGetLogEndpoint } from "./get-log";
+export { createInsertLogEndpoint } from "./insert-log";

--- a/src/endpoints/insert-log.ts
+++ b/src/endpoints/insert-log.ts
@@ -1,0 +1,45 @@
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
+import { z } from "zod";
+import type { AuditLogSeverity, AuditLogStatus, ResolvedOptions } from "../types";
+import { buildLogEntryFromAction, writeEntry } from "../internal";
+
+export function createInsertLogEndpoint(opts: ResolvedOptions, modelName: string) {
+  return createAuthEndpoint(
+    "/audit-log/insert",
+    {
+      method: "POST",
+      use: [sessionMiddleware],
+      body: z.object({
+        action: z.string().min(1),
+        status: z.enum(["success", "failed"]).optional().default("success"),
+        severity: z.enum(["low", "medium", "high", "critical"]).optional(),
+        metadata: z.record(z.string(), z.unknown()).optional().default({}),
+      }),
+    },
+    async (ctx) => {
+      const session = ctx.context.session;
+      const { action, status, severity, metadata } = ctx.body;
+
+      const entry = await buildLogEntryFromAction(
+        action,
+        status as AuditLogStatus,
+        {
+          userId: session.user.id,
+          request: ctx.request,
+          headers: ctx.headers,
+          metadata: metadata as Record<string, unknown>,
+          options: opts,
+          authOptions: ctx.context.options,
+        },
+      );
+
+      if (severity) {
+        entry.severity = severity as AuditLogSeverity;
+      }
+
+      await writeEntry(ctx, entry, opts, modelName);
+
+      return ctx.json({ success: true });
+    },
+  );
+}

--- a/src/endpoints/list-logs.ts
+++ b/src/endpoints/list-logs.ts
@@ -1,0 +1,86 @@
+import { createAuthEndpoint, sessionMiddleware, APIError } from "better-auth/api";
+import type { Where } from "better-auth";
+import { z } from "zod";
+import type { AuditLogEntry, ResolvedOptions, StorageReadOptions } from "../types";
+
+export function createListLogsEndpoint(opts: ResolvedOptions, modelName: string) {
+  return createAuthEndpoint(
+    "/audit-log/list",
+    {
+      method: "GET",
+      use: [sessionMiddleware],
+      query: z.object({
+        userId: z.string().optional(),
+        action: z.string().optional(),
+        status: z.enum(["success", "failed"]).optional(),
+        from: z.string().optional(),
+        to: z.string().optional(),
+        limit: z.coerce.number().min(1).max(500).optional().default(50),
+        offset: z.coerce.number().min(0).optional().default(0),
+      }),
+    },
+    async (ctx) => {
+      const session = ctx.context.session;
+      const targetUserId = ctx.query.userId ?? session.user.id;
+
+      if (targetUserId !== session.user.id) {
+        throw new APIError("FORBIDDEN", {
+          message: "Cannot query other users' audit logs",
+        });
+      }
+
+      const fromDate = ctx.query.from ? new Date(ctx.query.from) : undefined;
+      const toDate = ctx.query.to ? new Date(ctx.query.to) : undefined;
+
+      if (opts.storage?.read) {
+        const readOpts: StorageReadOptions = {
+          userId: targetUserId,
+          action: ctx.query.action,
+          status: ctx.query.status,
+          from: fromDate,
+          to: toDate,
+          limit: ctx.query.limit,
+          offset: ctx.query.offset,
+        };
+        const result = await opts.storage.read(readOpts);
+        return ctx.json(result);
+      }
+
+      const where: Where[] = [{ field: "userId", value: targetUserId }];
+
+      if (ctx.query.action) {
+        where.push({ field: "action", value: ctx.query.action });
+      }
+      if (ctx.query.status) {
+        where.push({ field: "status", value: ctx.query.status });
+      }
+      if (fromDate) {
+        where.push({ field: "createdAt", operator: "gte", value: fromDate });
+      }
+      if (toDate) {
+        where.push({ field: "createdAt", operator: "lte", value: toDate });
+      }
+
+      const [entries, total] = await Promise.all([
+        ctx.context.adapter.findMany<Record<string, unknown>>({
+          model: modelName,
+          where,
+          sortBy: { field: "createdAt", direction: "desc" },
+          limit: ctx.query.limit,
+          offset: ctx.query.offset,
+        }),
+        ctx.context.adapter.count({ model: modelName, where }),
+      ]);
+
+      const parsed = entries.map((e) => ({
+        ...(e as Omit<AuditLogEntry, "metadata">),
+        metadata:
+          typeof e["metadata"] === "string"
+            ? (JSON.parse(e["metadata"]) as Record<string, unknown>)
+            : ((e["metadata"] as Record<string, unknown>) ?? {}),
+      }));
+
+      return ctx.json({ entries: parsed, total });
+    },
+  );
+}


### PR DESCRIPTION
list-logs (GET /audit-log/list):
- Paginated with limit (1-500, default 50) and offset
- Filterable by userId, action, status, date range (from/to)
- userId defaults to session user; querying another user's logs is blocked at v1 with a FORBIDDEN error (admin support via beforeLog in a follow-up)
- Routes through opts.storage.read if custom storage is configured, otherwise falls back to ctx.context.adapter.findMany with parallel count

get-log (GET /audit-log/:id):
- Returns a single entry; enforces ownership (userId must match session user)
- Routes through opts.storage.readById if available, else adapter.findOne
- Deserialises metadata from JSON string on DB reads

insert-log (POST /audit-log/insert):
- Manual escape hatch for non-auth events (e.g. admin table mutations)
- Requires active session; severity can be overridden in the request body
- Uses buildLogEntryFromAction (skips path normalisation — action is caller-provided)
- PII redaction applied to metadata if enabled in plugin options