### PR TITLE
feat(plugin): assemble auditLog() factory and public API surface

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-console.log("Hello via Bun!");
+export * from "./src/index";

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,13 @@
+import type { BetterAuthClientPlugin } from "better-auth/client";
+import type { auditLog } from "./plugin";
+
+export const auditLogClient = () =>
+  ({
+    id: "audit-log",
+    $InferServerPlugin: {} as ReturnType<typeof auditLog>,
+    pathMethods: {
+      "/audit-log/list": "GET",
+      "/audit-log/:id": "GET",
+      "/audit-log/insert": "POST",
+    },
+  }) satisfies BetterAuthClientPlugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+export { auditLog } from "./plugin";
+export { MemoryStorage } from "./adapters/memory";
+export type {
+  AuditLogEntry,
+  AuditLogOptions,
+  AuditLogStorage,
+  AuditLogStatus,
+  AuditLogSeverity,
+  StorageReadOptions,
+  StorageReadResult,
+  PIIRedactionOptions,
+  CaptureOptions,
+  PathConfig,
+  RetentionConfig,
+} from "./types";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,77 @@
+import type { BetterAuthPlugin } from "better-auth";
+import { buildSchema, getModelName } from "./schema";
+import { createBeforeHooks, createAfterHooks } from "./hooks";
+import {
+  createListLogsEndpoint,
+  createGetLogEndpoint,
+  createInsertLogEndpoint,
+} from "./endpoints";
+import type {
+  AuditLogOptions,
+  PathConfig,
+  ResolvedOptions,
+} from "./types";
+
+function resolveOptions(options?: AuditLogOptions): ResolvedOptions {
+  const pathsMap = new Map<string, PathConfig | undefined>();
+  const hasPaths = (options?.paths?.length ?? 0) > 0;
+
+  for (const p of options?.paths ?? []) {
+    if (typeof p === "string") {
+      pathsMap.set(p, undefined);
+    } else {
+      pathsMap.set(p.path, p.config);
+    }
+  }
+
+  return {
+    enabled: options?.enabled ?? true,
+    nonBlocking: options?.nonBlocking ?? false,
+    storage: options?.storage,
+    capture: {
+      ipAddress: options?.capture?.ipAddress ?? true,
+      userAgent: options?.capture?.userAgent ?? true,
+      requestBody: options?.capture?.requestBody ?? false,
+    },
+    piiRedaction: {
+      enabled: options?.piiRedaction?.enabled ?? false,
+      fields: options?.piiRedaction?.fields,
+      strategy: options?.piiRedaction?.strategy ?? "mask",
+    },
+    retention: options?.retention,
+    beforeLog: options?.beforeLog,
+    afterLog: options?.afterLog,
+    shouldCapture: (path: string) => !hasPaths || pathsMap.has(path),
+    getPathConfig: (path: string) => pathsMap.get(path),
+  };
+}
+
+export function auditLog(options?: AuditLogOptions) {
+  const schema = buildSchema(options);
+  const modelName = getModelName(options);
+  const resolved = resolveOptions(options);
+
+  const beforeHooks = resolved.enabled ? createBeforeHooks(resolved, modelName) : [];
+  const afterHooks = resolved.enabled ? createAfterHooks(resolved, modelName) : [];
+
+  return {
+    id: "audit-log",
+    schema,
+    hooks: {
+      before: beforeHooks,
+      after: afterHooks,
+    },
+    endpoints: {
+      listAuditLogs: createListLogsEndpoint(resolved, modelName),
+      getAuditLog: createGetLogEndpoint(resolved, modelName),
+      insertAuditLog: createInsertLogEndpoint(resolved, modelName),
+    },
+    rateLimit: [
+      {
+        pathMatcher: (path: string) => path.startsWith("/audit-log/"),
+        window: 60,
+        max: 60,
+      },
+    ],
+  } satisfies BetterAuthPlugin;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export interface ResolvedOptions {
   nonBlocking: boolean;
   storage: AuditLogStorage | undefined;
   capture: Required<CaptureOptions>;
-  piiRedaction: Required<PIIRedactionOptions>;
+  piiRedaction: { enabled: boolean; fields?: string[]; strategy: PIIStrategy };
   retention: RetentionConfig | undefined;
   beforeLog: AuditLogOptions["beforeLog"];
   afterLog: AuditLogOptions["afterLog"];


### PR DESCRIPTION
plugin.ts:
- resolveOptions() fills all defaults and builds shouldCapture/getPathConfig helpers from the paths whitelist; empty paths means capture everything
- auditLog() wires hooks, endpoints, schema, and rate-limit into a single BetterAuthPlugin; hooks are empty arrays when enabled: false so the plugin can be disabled without removal

src/index.ts: exports plugin, MemoryStorage, and all public types src/client.ts: auditLogClient() with $InferServerPlugin for typed client calls
  and pathMethods declaring GET for list and get-by-id

Root index.ts re-exports src/index.ts as the package entry point