### PR TITLE
test: add unit tests for plugin, adapters, and utilities

### DIFF
--- a/tests/adapters/memory.test.ts
+++ b/tests/adapters/memory.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { MemoryStorage } from "../../src/adapters/memory";
+import type { AuditLogEntry } from "../../src/types";
+
+function makeEntry(overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    id: crypto.randomUUID(),
+    userId: "user-1",
+    action: "sign-in:email",
+    status: "success",
+    severity: "medium",
+    ipAddress: "127.0.0.1",
+    userAgent: "test-agent",
+    metadata: {},
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("MemoryStorage", () => {
+  let store: MemoryStorage;
+
+  beforeEach(() => {
+    store = new MemoryStorage();
+  });
+
+  test("write stores an entry", async () => {
+    const entry = makeEntry();
+    await store.write(entry);
+    expect(store.entries).toHaveLength(1);
+    expect(store.entries[0]?.id).toBe(entry.id);
+  });
+
+  test("read returns all entries when no filters", async () => {
+    await store.write(makeEntry());
+    await store.write(makeEntry());
+    const result = await store.read({ limit: 10, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.entries).toHaveLength(2);
+  });
+
+  test("read filters by userId", async () => {
+    await store.write(makeEntry({ userId: "user-1" }));
+    await store.write(makeEntry({ userId: "user-2" }));
+    const result = await store.read({ userId: "user-1", limit: 10, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.entries[0]?.userId).toBe("user-1");
+  });
+
+  test("read filters by action", async () => {
+    await store.write(makeEntry({ action: "sign-in:email" }));
+    await store.write(makeEntry({ action: "sign-out" }));
+    const result = await store.read({
+      action: "sign-out",
+      limit: 10,
+      offset: 0,
+    });
+    expect(result.total).toBe(1);
+    expect(result.entries[0]?.action).toBe("sign-out");
+  });
+
+  test("read filters by status", async () => {
+    await store.write(makeEntry({ status: "success" }));
+    await store.write(makeEntry({ status: "failed" }));
+    const result = await store.read({
+      status: "failed",
+      limit: 10,
+      offset: 0,
+    });
+    expect(result.total).toBe(1);
+    expect(result.entries[0]?.status).toBe("failed");
+  });
+
+  test("read filters by date range", async () => {
+    const past = new Date(Date.now() - 60_000);
+    const future = new Date(Date.now() + 60_000);
+    const old = makeEntry({ createdAt: new Date(Date.now() - 120_000) });
+    const recent = makeEntry({ createdAt: new Date() });
+
+    await store.write(old);
+    await store.write(recent);
+
+    const result = await store.read({ from: past, to: future, limit: 10, offset: 0 });
+    expect(result.total).toBe(1);
+  });
+
+  test("read paginates with limit and offset", async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.write(makeEntry({ id: `entry-${i}` }));
+    }
+    const page1 = await store.read({ limit: 2, offset: 0 });
+    const page2 = await store.read({ limit: 2, offset: 2 });
+    expect(page1.entries).toHaveLength(2);
+    expect(page2.entries).toHaveLength(2);
+    expect(page1.total).toBe(5);
+  });
+
+  test("read returns entries sorted newest first", async () => {
+    const older = makeEntry({ createdAt: new Date(Date.now() - 5000) });
+    const newer = makeEntry({ createdAt: new Date() });
+    await store.write(older);
+    await store.write(newer);
+    const result = await store.read({ limit: 10, offset: 0 });
+    expect(result.entries[0]?.id).toBe(newer.id);
+  });
+
+  test("readById returns the matching entry", async () => {
+    const entry = makeEntry({ id: "target" });
+    await store.write(entry);
+    await store.write(makeEntry({ id: "other" }));
+    const found = await store.readById("target");
+    expect(found?.id).toBe("target");
+  });
+
+  test("readById returns null when not found", async () => {
+    const found = await store.readById("nonexistent");
+    expect(found).toBeNull();
+  });
+
+  test("deleteOlderThan removes old entries and returns count", async () => {
+    const old = makeEntry({ createdAt: new Date(Date.now() - 120_000) });
+    const recent = makeEntry({ createdAt: new Date() });
+    await store.write(old);
+    await store.write(recent);
+
+    const cutoff = new Date(Date.now() - 60_000);
+    const deleted = await store.deleteOlderThan(cutoff);
+
+    expect(deleted).toBe(1);
+    expect(store.entries).toHaveLength(1);
+    expect(store.entries[0]?.id).toBe(recent.id);
+  });
+});

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from "bun:test";
+import { auditLog } from "../src/plugin";
+import { BEFORE_PATHS } from "../src/hooks/before";
+import type { HookEndpointContext } from "@better-auth/core";
+
+function makeContext(path: string): HookEndpointContext {
+  return {
+    path,
+    context: {} as HookEndpointContext["context"],
+  };
+}
+
+describe("auditLog plugin", () => {
+  test("returns a valid BetterAuthPlugin shape", () => {
+    const plugin = auditLog();
+    expect(plugin.id).toBe("audit-log");
+    expect(Array.isArray(plugin.hooks.before)).toBe(true);
+    expect(Array.isArray(plugin.hooks.after)).toBe(true);
+    expect(plugin.schema).toBeDefined();
+    expect(plugin.endpoints.listAuditLogs).toBeDefined();
+    expect(plugin.endpoints.getAuditLog).toBeDefined();
+    expect(plugin.endpoints.insertAuditLog).toBeDefined();
+  });
+
+  test("before hook matcher fires for all BEFORE_PATHS", () => {
+    const plugin = auditLog();
+    const [hook] = plugin.hooks.before;
+    for (const path of BEFORE_PATHS) {
+      expect(hook!.matcher(makeContext(path))).toBe(true);
+    }
+  });
+
+  test("before hook matcher does not fire for after-only paths", () => {
+    const plugin = auditLog();
+    const [hook] = plugin.hooks.before;
+    expect(hook!.matcher(makeContext("/sign-in/email"))).toBe(false);
+    expect(hook!.matcher(makeContext("/sign-up/email"))).toBe(false);
+  });
+
+  test("after hook matcher fires for non-before paths", () => {
+    const plugin = auditLog();
+    const [hook] = plugin.hooks.after;
+    expect(hook!.matcher(makeContext("/sign-in/email"))).toBe(true);
+    expect(hook!.matcher(makeContext("/sign-up/email"))).toBe(true);
+    expect(hook!.matcher(makeContext("/change-password"))).toBe(true);
+  });
+
+  test("after hook matcher excludes BEFORE_PATHS", () => {
+    const plugin = auditLog();
+    const [hook] = plugin.hooks.after;
+    for (const path of BEFORE_PATHS) {
+      expect(hook!.matcher(makeContext(path))).toBe(false);
+    }
+  });
+
+  test("paths whitelist restricts which paths are captured", () => {
+    const plugin = auditLog({ paths: ["/sign-in/email"] });
+    const [afterHook] = plugin.hooks.after;
+    expect(afterHook!.matcher(makeContext("/sign-in/email"))).toBe(true);
+    expect(afterHook!.matcher(makeContext("/sign-up/email"))).toBe(false);
+  });
+
+  test("paths whitelist restricts before-hooks too", () => {
+    const plugin = auditLog({ paths: ["/sign-in/email"] });
+    const [beforeHook] = plugin.hooks.before;
+    expect(beforeHook!.matcher(makeContext("/sign-out"))).toBe(false);
+  });
+
+  test("when enabled: false, hook arrays are empty", () => {
+    const plugin = auditLog({ enabled: false });
+    expect(plugin.hooks.before).toHaveLength(0);
+    expect(plugin.hooks.after).toHaveLength(0);
+  });
+
+  test("schema uses default model name when not overridden", () => {
+    const plugin = auditLog();
+    expect(plugin.schema.auditLog).toBeDefined();
+  });
+
+  test("schema respects custom model name", () => {
+    const plugin = auditLog({ schema: { auditLog: { modelName: "audit_events" } } });
+    const modelName =
+      (plugin.schema.auditLog as { modelName?: string }).modelName ?? "auditLog";
+    expect(modelName).toBe("audit_events");
+  });
+
+  test("rate limit is applied to /audit-log/ paths", () => {
+    const plugin = auditLog();
+    const [limit] = plugin.rateLimit!;
+    expect(limit!.pathMatcher("/audit-log/list")).toBe(true);
+    expect(limit!.pathMatcher("/sign-in/email")).toBe(false);
+  });
+});

--- a/tests/utils/normalize-path.test.ts
+++ b/tests/utils/normalize-path.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test";
+import { normalizePath } from "../../src/utils/normalize-path";
+
+describe("normalizePath", () => {
+  test("strips leading slash", () => {
+    expect(normalizePath("/sign-out")).toBe("sign-out");
+  });
+
+  test("converts nested path to colon-separated action", () => {
+    expect(normalizePath("/sign-in/email")).toBe("sign-in:email");
+  });
+
+  test("handles three-level paths", () => {
+    expect(normalizePath("/two-factor/totp/verify")).toBe(
+      "two-factor:totp:verify",
+    );
+  });
+
+  test("leaves already-normalised strings unchanged", () => {
+    expect(normalizePath("sign-out")).toBe("sign-out");
+  });
+});

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "bun:test";
+import { redactPII } from "../../src/utils/sanitize";
+
+describe("redactPII", () => {
+  test("masks password by default", async () => {
+    const result = await redactPII(
+      { email: "user@example.com", password: "secret123" },
+      { enabled: true, strategy: "mask" },
+    );
+    expect(result.password).toBe("[REDACTED]");
+    expect(result.email).toBe("user@example.com");
+  });
+
+  test("removes fields with remove strategy", async () => {
+    const result = await redactPII(
+      { password: "secret", token: "abc" },
+      { enabled: true, strategy: "remove" },
+    );
+    expect("password" in result).toBe(false);
+    expect("token" in result).toBe(false);
+  });
+
+  test("hashes fields with hash strategy", async () => {
+    const result = await redactPII(
+      { password: "secret" },
+      { enabled: true, strategy: "hash" },
+    );
+    expect(typeof result.password).toBe("string");
+    expect((result.password as string).length).toBe(64);
+  });
+
+  test("same input produces same hash", async () => {
+    const a = await redactPII(
+      { password: "deterministic" },
+      { enabled: true, strategy: "hash" },
+    );
+    const b = await redactPII(
+      { password: "deterministic" },
+      { enabled: true, strategy: "hash" },
+    );
+    expect(a.password).toBe(b.password);
+  });
+
+  test("skips redaction when disabled", async () => {
+    const result = await redactPII(
+      { password: "secret" },
+      { enabled: false },
+    );
+    expect(result.password).toBe("secret");
+  });
+
+  test("skips null/undefined fields", async () => {
+    const result = await redactPII(
+      { password: null },
+      { enabled: true, strategy: "mask" },
+    );
+    expect(result.password).toBeNull();
+  });
+
+  test("respects custom field list", async () => {
+    const result = await redactPII(
+      { email: "user@example.com", customField: "sensitive" },
+      { enabled: true, strategy: "mask", fields: ["customField"] },
+    );
+    expect(result.customField).toBe("[REDACTED]");
+    expect(result.email).toBe("user@example.com");
+  });
+});


### PR DESCRIPTION
plugin.test.ts (11 tests):
- Validates BetterAuthPlugin shape and all endpoint presence
- Before hook matcher fires for all 5 BEFORE_PATHS and ignores after-only paths
- After hook matcher fires for non-before paths and excludes BEFORE_PATHS
- Paths whitelist restricts capture for both before and after hooks
- enabled: false produces empty hook arrays
- Rate-limit pathMatcher correctly scopes to /audit-log/ prefix

memory.test.ts (11 tests):
- Write, read with all filter combinations (userId, action, status, date range)
- Pagination via limit/offset; newest-first sort order on read
- readById returns correct entry and null for missing id
- deleteOlderThan removes only stale entries and returns correct count

sanitize.test.ts (7 tests):
- mask, remove, hash strategies; hash is 64-char hex (SHA-256)
- Deterministic: same input produces same hash across calls
- disabled redaction passes data through unchanged
- null/undefined field values are skipped
- Custom field list overrides defaults

normalize-path.test.ts (4 tests):
- Leading slash stripped, slashes converted to colons
- Three-level paths, already-normalised strings unchanged