### PR TITLE
fix(schema): use audit_log as default DB table name

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3,6 +3,7 @@ import type { AuditLogOptions } from "./types";
 
 export const baseSchema = {
   auditLog: {
+    modelName: "audit_log",
     fields: {
       userId: {
         type: "string" as const,
@@ -59,5 +60,5 @@ export function buildSchema(options?: AuditLogOptions) {
 }
 
 export function getModelName(options?: AuditLogOptions): string {
-  return options?.schema?.auditLog?.modelName ?? "auditLog";
+  return options?.schema?.auditLog?.modelName ?? "audit_log";
 }

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -80,7 +80,7 @@ describe("auditLog plugin", () => {
   test("schema respects custom model name", () => {
     const plugin = auditLog({ schema: { auditLog: { modelName: "audit_events" } } });
     const modelName =
-      (plugin.schema.auditLog as { modelName?: string }).modelName ?? "auditLog";
+      (plugin.schema.auditLog as { modelName?: string }).modelName ?? "audit_log";
     expect(modelName).toBe("audit_events");
   });
 


### PR DESCRIPTION
The JS identifier "auditLog" is the plugin-internal schema key. The actual DB table name (modelName) should follow SQL conventions — snake_case.

Default: "audit_log". Overridable via schema.auditLog.modelName as before.