### PR TITLE
fix: log actual errors to server before returning generic 500s

### DIFF
--- a/src/endpoints/get-log.ts
+++ b/src/endpoints/get-log.ts
@@ -48,7 +48,6 @@ export function createGetLogEndpoint(opts: ResolvedOptions, modelName: string) {
 
         let metadata = parseMetadata(record["metadata"]);
 
-        // SECU-02: Apply PII redaction on read path
         if (opts.piiRedaction.enabled) {
           metadata = await redactPII(metadata, opts.piiRedaction);
         }
@@ -61,6 +60,7 @@ export function createGetLogEndpoint(opts: ResolvedOptions, modelName: string) {
         return ctx.json(entry);
       } catch (err) {
         if (err instanceof APIError) throw err;
+        ctx.context.logger?.error("[audit-log] get failed", err);
         throw new APIError("INTERNAL_SERVER_ERROR", {
           message: "Failed to retrieve audit log entry",
         });

--- a/src/endpoints/insert-log.ts
+++ b/src/endpoints/insert-log.ts
@@ -47,6 +47,7 @@ export function createInsertLogEndpoint(opts: ResolvedOptions, modelName: string
         return ctx.json({ success: true });
       } catch (err) {
         if (err instanceof APIError) throw err;
+        ctx.context.logger?.error("[audit-log] insert failed", err);
         throw new APIError("INTERNAL_SERVER_ERROR", {
           message: "Failed to insert audit log entry",
         });

--- a/src/endpoints/list-logs.ts
+++ b/src/endpoints/list-logs.ts
@@ -93,7 +93,6 @@ export function createListLogsEndpoint(opts: ResolvedOptions, modelName: string)
           metadata: parseMetadata(e["metadata"]),
         })) as AuditLogEntry[];
 
-        // SECU-02: Apply PII redaction on read path
         if (opts.piiRedaction.enabled) {
           parsed = await Promise.all(
             parsed.map(async (e) => ({
@@ -106,6 +105,7 @@ export function createListLogsEndpoint(opts: ResolvedOptions, modelName: string)
         return ctx.json({ entries: parsed, total });
       } catch (err) {
         if (err instanceof APIError) throw err;
+        ctx.context.logger?.error("[audit-log] list failed", err);
         throw new APIError("INTERNAL_SERVER_ERROR", {
           message: "Failed to retrieve audit logs",
         });

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -45,7 +45,6 @@ describe("hook execution", () => {
     const arg = makeHandlerArg("/sign-in/email");
     expect(afterHook!.matcher(arg as unknown as HookEndpointContext)).toBe(true);
 
-    // createAuthMiddleware wraps the handler; call it with the context directly
     await (afterHook!.handler as Function)(arg);
 
     expect(storage.entries).toHaveLength(1);
@@ -76,7 +75,6 @@ describe("hook execution", () => {
     const arg = makeHandlerArg("/sign-out");
     expect(beforeHook!.matcher(arg as unknown as HookEndpointContext)).toBe(true);
 
-    // getSessionFromCtx may fail with our mock, but the hook catches the error
     await (beforeHook!.handler as Function)(arg);
   });
 

--- a/tests/internal.test.ts
+++ b/tests/internal.test.ts
@@ -60,7 +60,6 @@ function makeCtx(
       },
       options: {},
     },
-    // expose for test assertions
     _backgroundTasks: backgroundTasks,
   } as unknown as GenericEndpointContext & { _backgroundTasks: Promise<unknown>[] };
 }
@@ -169,11 +168,9 @@ describe("writeEntry", () => {
       _backgroundTasks: Promise<unknown>[];
     };
 
-    // writeEntry should return immediately
     await writeEntry(ctx, makeEntry(), opts, "auditLog");
     expect(writeResolved).toBe(false);
 
-    // Wait for the background task to complete
     await Promise.all(ctx._backgroundTasks);
     expect(writeResolved).toBe(true);
   });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -65,11 +65,9 @@ describe("auditLog plugin", () => {
     const [beforeHook] = plugin.hooks.before;
     const [afterHook] = plugin.hooks.after;
 
-    // Custom path should be before-only
     expect(beforeHook!.matcher(makeContext("/custom-action"))).toBe(true);
     expect(afterHook!.matcher(makeContext("/custom-action"))).toBe(false);
 
-    // Default before path should now be after-only
     expect(beforeHook!.matcher(makeContext("/sign-out"))).toBe(false);
     expect(afterHook!.matcher(makeContext("/sign-out"))).toBe(true);
   });

--- a/tests/utils/retry.test.ts
+++ b/tests/utils/retry.test.ts
@@ -34,7 +34,7 @@ describe("withRetry", () => {
       }, { maxRetries: 2, baseDelayMs: 10 }),
     ).rejects.toThrow("persistent failure");
 
-    expect(calls).toBe(3); // initial + 2 retries
+    expect(calls).toBe(3);
   });
 
   test("with zero retries, throws immediately", async () => {


### PR DESCRIPTION
Endpoint catch blocks were swallowing the real error and only returning a static message to the client. Now logs the original error via ctx.context.logger before throwing the sanitized APIError, so operators can diagnose failures from server logs.