### PR TITLE
Pass ctx into beforeLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,9 @@ auditLog({
     days: 90,                // delete entries older than N days
   },
 
-  // intercept before write — return null to suppress
-  beforeLog: async (entry) => {
+  // intercept before write — return null to suppress. Receives the endpoint
+  // ctx as a second argument, so you can resolve the session or read the request.
+  beforeLog: async (entry, ctx) => {
     if (entry.userId === "service-account") return null;
     return entry;
   },
@@ -207,6 +208,29 @@ auditLog({
 ```
 
 To override the DB model name, pass `schema: { auditLog: { modelName: "your_table_name" } }`.
+
+## Adding additional metadata to log entries
+
+`beforeLog` is the injection point for extra per-entry data. Because it receives the
+endpoint `ctx`, you can resolve the session and stash a value such as the active
+organization into `metadata` — which is stored as JSON and returned intact:
+
+```ts
+import { getSessionFromCtx } from "better-auth/api";
+
+auditLog({
+  beforeLog: async (entry, ctx) => {
+    const session = await getSessionFromCtx(ctx);
+    return {
+      ...entry,
+      metadata: {
+        ...entry.metadata,
+        activeOrganizationId: session?.session?.activeOrganizationId ?? null,
+      },
+    };
+  },
+});
+```
 
 ## Custom storage
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -101,7 +101,7 @@ export async function writeEntry(
     let finalEntry = entry;
 
     if (opts.beforeLog) {
-      const modified = await opts.beforeLog(finalEntry);
+      const modified = await opts.beforeLog(finalEntry, ctx);
       if (modified === null) return;
 
       const validated = validateEntry(modified, ctx.context.logger);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+
 export type AuditLogStatus = "success" | "failed";
 export type AuditLogSeverity = "low" | "medium" | "high" | "critical";
 export type PIIStrategy = "mask" | "hash" | "remove";
@@ -81,6 +83,7 @@ export interface AuditLogOptions {
   };
   beforeLog?: (
     entry: Omit<AuditLogEntry, "id">,
+    ctx: GenericEndpointContext,
   ) => Promise<Omit<AuditLogEntry, "id"> | null>;
   afterLog?: (entry: AuditLogEntry) => Promise<void>;
   onWriteError?: (error: unknown, entry: Omit<AuditLogEntry, "id">) => void;

--- a/tests/internal.test.ts
+++ b/tests/internal.test.ts
@@ -107,6 +107,61 @@ describe("writeEntry", () => {
     expect(written.action).toBe("modified-action");
   });
 
+  test("beforeLog receives ctx as its second argument", async () => {
+    let received: unknown;
+    const opts = makeOpts({
+      storage: { write: mock(async () => {}) },
+      beforeLog: async (entry, ctx) => {
+        received = ctx;
+        return entry;
+      },
+    });
+    const ctx = makeCtx();
+
+    await writeEntry(ctx, makeEntry(), opts, "auditLog");
+
+    expect(received).toBe(ctx);
+  });
+
+  test("beforeLog can add a metadata field (custom storage)", async () => {
+    const writeFn = mock(async () => {});
+    const opts = makeOpts({
+      storage: { write: writeFn },
+      beforeLog: async (entry) => ({
+        ...entry,
+        metadata: { ...entry.metadata, organizationId: "org-1" },
+      }),
+    });
+    const ctx = makeCtx();
+
+    await writeEntry(ctx, makeEntry(), opts, "auditLog");
+
+    const written = (writeFn.mock.calls[0] as unknown[])[0] as AuditLogEntry;
+    expect(written.metadata.organizationId).toBe("org-1");
+  });
+
+  test("beforeLog metadata field is persisted through the adapter", async () => {
+    const createFn = mock(async () => ({
+      id: "adapter-id",
+      ...makeEntry(),
+      metadata: "{}",
+    }));
+    const ctx = makeCtx({ create: createFn });
+    const opts = makeOpts({
+      beforeLog: async (entry) => ({
+        ...entry,
+        metadata: { ...entry.metadata, organizationId: "org-1" },
+      }),
+    });
+
+    await writeEntry(ctx, makeEntry(), opts, "auditLog");
+
+    const arg = (createFn.mock.calls[0] as unknown[])[0] as {
+      data: { metadata: string };
+    };
+    expect(JSON.parse(arg.data.metadata).organizationId).toBe("org-1");
+  });
+
   test("beforeLog returning null skips the write", async () => {
     const writeFn = mock(async () => {});
     const opts = makeOpts({


### PR DESCRIPTION
This passes the endpoint `ctx` as a second argument to beforeLog, so callbacks can resolve the session or read request data when building a log entry. This is backwards compatible.

My use-case is adding the user's `activeOrganizationId` into metadata (so org admins can later be shown only logs from within their org) but I imagine there are other use cases people will find with being able to access the request data (e.g. `activeTeamId`).

I considered adding a dedicated `organizationId` column instead, but that was quite a bit more involved - updating `/audit-log/list` to support org querying, access-control for who can read which logs, etc. I decided that was too much for the library and I'll handle it in the application myself with a new endpoint so I can change the parameters, plus making the `metadata` column JSONB and filtering directly in the ORM (better-auth's DB abstraction doesn't allow that).
