### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+  node:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24, 26]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          # No npm lockfile in this repo, so disable the package-manager cache.
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Smoke-test the built package on Node
+        run: node scripts/node-smoke.mjs

--- a/scripts/node-smoke.mjs
+++ b/scripts/node-smoke.mjs
@@ -1,0 +1,42 @@
+// Node smoke test: verify the built package actually works on Node (not just Bun).
+// Exercises both the ESM and CJS entry points — instantiates the plugin and
+// round-trips an entry through MemoryStorage. Run against ./dist after building.
+import { createRequire } from "node:module";
+import assert from "node:assert/strict";
+
+const require = createRequire(import.meta.url);
+
+async function exercise(mod, label) {
+  const { auditLog, MemoryStorage } = mod;
+  assert.equal(typeof auditLog, "function", `${label}: auditLog is not a function`);
+  assert.equal(typeof MemoryStorage, "function", `${label}: MemoryStorage is not a constructor`);
+
+  const plugin = auditLog();
+  assert.equal(plugin.id, "audit-log", `${label}: unexpected plugin id`);
+  assert.ok(plugin.schema?.auditLog, `${label}: plugin is missing the auditLog schema`);
+  assert.ok(plugin.endpoints, `${label}: plugin is missing endpoints`);
+
+  const storage = new MemoryStorage();
+  const entry = {
+    id: "smoke-1",
+    userId: null,
+    action: "sign-in:email",
+    status: "success",
+    severity: "info",
+    ipAddress: null,
+    userAgent: null,
+    metadata: {},
+    createdAt: new Date(),
+  };
+  await storage.write(entry);
+  const result = await storage.read({ limit: 10, offset: 0 });
+  assert.equal(result.entries.length, 1, `${label}: entry did not round-trip`);
+  assert.equal(result.entries[0].id, "smoke-1", `${label}: wrong entry read back`);
+
+  console.log(`${label}: ok`);
+}
+
+await exercise(await import("../dist/index.js"), "esm");
+await exercise(require("../dist/index.cjs"), "cjs");
+
+console.log("smoke: all checks passed");


### PR DESCRIPTION
Add a CI workflow that:
- runs typecheck and tests on Bun
- smoke-tests the built package across a Node 20/22/24/26 matrix to verify the shipped `dist` loads and works on Node

To harden the workflow I've pinned actions by commit SHAs & scoped the workflow token to the minimum permissions needed.

I got Claude create `scripts/node-smoke.mjs`, which is why it's listed as a co-author on the commit.

EDIT: I've got a commit to do releases via GH Actions too here https://github.com/Stotles/better-auth-audit-logs/commit/191dee1ca30ff62721d643a3771ca617c36a897e, not opening a PR up for this yet to not bombard you with PRs - sorry about opening 3 in quick succession.

EDIT 2: You can see the CI action working in this PR https://github.com/Stotles/better-auth-audit-logs/pull/1